### PR TITLE
No separate build folder

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -59,6 +59,7 @@ namespace DropDownloadCore
 
         private static bool IsVSTSBuild()
         {
+            Console.WriteLine($"system host type: {Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE")}");
             return Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE") == "build";
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -57,24 +57,27 @@ namespace DropDownloadCore
             }
         }
 
+        private static string findDropJson(string workingDirectory)
+        {
+            try 
+            {
+                string[] vstsDrops = Directory.GetFiles(workingDirectory, "*/VSTSDrop.json", SearchOption.AllDirectories);
+                return vstsDrops.Single();
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine($"The working directory, {workingDirectory}, is invalid");
+                Console.WriteLine(e.Message);
+                throw;
+            }
+        }
+
         // agent based tasks automatically download artifacts from the build. 
         // when the build only produces a vsts drop that artifact is a single json
         // it resides in <builddefname>/<guid>/VSTSDrop.json
         private static string ExtractDropUrl(string workingDirectory)
         {
-            string guidDirectory = string.Empty;
-
-            try
-            {
-                guidDirectory = Directory.GetDirectories(workingDirectory).Single();
-            }
-            catch (Exception)
-            {
-                Console.WriteLine($"The build directory, {workingDirectory}, is invalid");
-                throw;
-            }
-
-            var dropJSONFilename = Path.Combine(workingDirectory,  guidDirectory, "VSTSDrop.json");
+            var dropJSONFilename = findDropJson(workingDirectory);
 
             // https://www.newtonsoft.com/json/help/html/DeserializeAnonymousType.htm
             var definition = new { VstsDropBuildArtifact = new {VstsDropUrl ="" } };

--- a/Program.cs
+++ b/Program.cs
@@ -47,14 +47,14 @@ namespace DropDownloadCore
             string[] childDirectories = Directory.GetDirectories(currDir);
 
             var parentPath = Path.GetFullPath(workingDirectory);
-            string[] siblingDirectories = Directory.GetDirectories(parentPath);
+            string[] siblingDirectories = Directory.GetDirectories("/Drop");
             Console.WriteLine("directories: ");
             foreach (string dir in siblingDirectories)
             {
                 Console.WriteLine(dir);
             }
 
-            string[] siblingFiles = Directory.GetFiles(parentPath);
+            string[] siblingFiles = Directory.GetFiles("/Drop");
             Console.WriteLine("files: ");
             foreach (string dir in siblingFiles)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -61,7 +61,7 @@ namespace DropDownloadCore
         {
             try 
             {
-                string[] vstsDrops = Directory.GetFiles(workingDirectory, "*/VSTSDrop.json", SearchOption.AllDirectories);
+                string[] vstsDrops = Directory.GetFiles(workingDirectory, "VSTSDrop.json", SearchOption.AllDirectories);
                 return vstsDrops.Single();
             }
             catch(Exception e)

--- a/Program.cs
+++ b/Program.cs
@@ -92,7 +92,7 @@ namespace DropDownloadCore
             try
             {
                 // guidDirectory = Directory.GetDirectories(buildDirectory).Single();
-                guidDirectory = Directory.GetDirectories(buildDirectory).Where(directory => directory != "drop").Single();
+                guidDirectory = Directory.GetDirectories(buildDirectory).Where(directory => directory.Remove(0,directory.LastIndexOf('/') + 1) != "drop").Single();
             }
             catch (Exception)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -52,7 +52,7 @@ namespace DropDownloadCore
                 Console.WriteLine(dir);
             }
 
-            var parentPath = Path.GetFullPath(currDir + "..");
+            var parentPath = Path.GetFullPath(currDir + "\\..");
             string[] siblingDirectories = Directory.GetDirectories(parentPath);
             Console.WriteLine("sibling directories: ");
             foreach (string dir in siblingDirectories)

--- a/Program.cs
+++ b/Program.cs
@@ -52,7 +52,7 @@ namespace DropDownloadCore
                 Console.WriteLine(dir);
             }
 
-            var parentPath = Path.GetFullPath(currDir + "\\..");
+            var parentPath = Path.GetFullPath("/");
             string[] siblingDirectories = Directory.GetDirectories(parentPath);
             Console.WriteLine("sibling directories: ");
             foreach (string dir in siblingDirectories)

--- a/Program.cs
+++ b/Program.cs
@@ -42,8 +42,23 @@ namespace DropDownloadCore
         {
             //could take an envdir on what the build dir is for now though we just have one build
             string guidDirectory = string.Empty;
+            string currDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            Console.WriteLine(currDir);
+            string[] childDirectories = Directory.GetDirectories(currDir);
 
-            Console.WriteLine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location));
+            Console.WriteLine("Child directories: ");
+            foreach (string dir in childDirectories)
+            {
+                Console.WriteLine(dir);
+            }
+
+            var parentPath = Path.GetFullPath(currDir + "..");
+            string[] siblingDirectories = Directory.GetDirectories(parentPath);
+            Console.WriteLine("sibling directories: ");
+            foreach (string dir in siblingDirectories)
+            {
+                Console.WriteLine(dir);
+            }
 
             try
             {

--- a/Program.cs
+++ b/Program.cs
@@ -66,7 +66,6 @@ namespace DropDownloadCore
             string guidDirectory = string.Empty;
             string currDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             Console.WriteLine(currDir);
-            string[] childDirectories = Directory.GetDirectories(currDir);
 
             try
             {

--- a/Program.cs
+++ b/Program.cs
@@ -46,21 +46,6 @@ namespace DropDownloadCore
             Console.WriteLine(currDir);
             string[] childDirectories = Directory.GetDirectories(currDir);
 
-            var parentPath = Path.GetFullPath(workingDirectory);
-            string[] siblingDirectories = Directory.GetDirectories("/drop");
-            Console.WriteLine("directories: ");
-            foreach (string dir in siblingDirectories)
-            {
-                Console.WriteLine(dir);
-            }
-
-            string[] siblingFiles = Directory.GetFiles("/drop");
-            Console.WriteLine("files: ");
-            foreach (string dir in siblingFiles)
-            {
-                Console.WriteLine(dir);
-            }
-
             try
             {
                 guidDirectory = Directory.GetDirectories(workingDirectory).Single();

--- a/Program.cs
+++ b/Program.cs
@@ -47,14 +47,14 @@ namespace DropDownloadCore
             string[] childDirectories = Directory.GetDirectories(currDir);
 
             var parentPath = Path.GetFullPath(workingDirectory);
-            string[] siblingDirectories = Directory.GetDirectories("/Drop");
+            string[] siblingDirectories = Directory.GetDirectories("/drop");
             Console.WriteLine("directories: ");
             foreach (string dir in siblingDirectories)
             {
                 Console.WriteLine(dir);
             }
 
-            string[] siblingFiles = Directory.GetFiles("/Drop");
+            string[] siblingFiles = Directory.GetFiles("/drop");
             Console.WriteLine("files: ");
             foreach (string dir in siblingFiles)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -46,16 +46,17 @@ namespace DropDownloadCore
             Console.WriteLine(currDir);
             string[] childDirectories = Directory.GetDirectories(currDir);
 
-            Console.WriteLine("Child directories: ");
-            foreach (string dir in childDirectories)
+            var parentPath = Path.GetFullPath(workingDirectory);
+            string[] siblingDirectories = Directory.GetDirectories(parentPath);
+            Console.WriteLine("directories: ");
+            foreach (string dir in siblingDirectories)
             {
                 Console.WriteLine(dir);
             }
 
-            var parentPath = Path.GetFullPath("/");
-            string[] siblingDirectories = Directory.GetDirectories(parentPath);
-            Console.WriteLine("sibling directories: ");
-            foreach (string dir in siblingDirectories)
+            string[] siblingFiles = Directory.GetFiles(parentPath);
+            Console.WriteLine("files: ");
+            foreach (string dir in siblingFiles)
             {
                 Console.WriteLine(dir);
             }

--- a/Program.cs
+++ b/Program.cs
@@ -59,7 +59,7 @@ namespace DropDownloadCore
 
         private static bool IsVSTSBuild()
         {
-            return System.GetEnvironmentVariable("SYSTEM_HOSTTYPE") == "build";
+            return Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE") == "build";
         }
 
         private static string GetBuildFolder(string workingDirectory)

--- a/Program.cs
+++ b/Program.cs
@@ -57,23 +57,45 @@ namespace DropDownloadCore
             }
         }
 
+        private static bool IsVSTSBuild()
+        {
+            return System.GetEnvironmentVariable("SYSTEM_HOSTTYPE") == "build";
+        }
+
+        private static string GetBuildFolder(string workingDirectory)
+        {
+            if (IsVSTSBuild())
+            {
+                return workingDirectory;
+            }
+
+            try
+            {
+                return Directory.GetDirectories(workingDirectory).Single();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"The working directory, {workingDirectory}, is invalid");
+                throw;
+            }
+        }
+
         // agent based tasks automatically download artifacts from the build. 
         // when the build only produces a vsts drop that artifact is a single json
         // it resides in <builddefname>/<guid>/VSTSDrop.json
         private static string ExtractDropUrl(string workingDirectory)
         {
-            //could take an envdir on what the build dir is for now though we just have one build
+            string buildDirectory = GetBuildFolder(workingDirectory);
             string guidDirectory = string.Empty;
-            string currDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-            Console.WriteLine(currDir);
 
             try
             {
-                guidDirectory = Directory.GetDirectories(workingDirectory).Single();
+                // guidDirectory = Directory.GetDirectories(buildDirectory).Single();
+                guidDirectory = Directory.GetDirectories(buildDirectory).Where(directory => directory != "drop").Single();
             }
             catch (Exception)
             {
-                Console.WriteLine($"The build directory, {workingDirectory}, is invalid");
+                Console.WriteLine($"The build directory, {buildDirectory}, is invalid");
                 throw;
             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -57,46 +57,20 @@ namespace DropDownloadCore
             }
         }
 
-        private static bool IsVSTSBuild()
-        {
-            Console.WriteLine($"system host type: {Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE")}");
-            return Environment.GetEnvironmentVariable("SYSTEM_HOSTTYPE") == "build";
-        }
-
-        private static string GetBuildFolder(string workingDirectory)
-        {
-            if (IsVSTSBuild())
-            {
-                return workingDirectory;
-            }
-
-            try
-            {
-                return Directory.GetDirectories(workingDirectory).Single();
-            }
-            catch (Exception)
-            {
-                Console.WriteLine($"The working directory, {workingDirectory}, is invalid");
-                throw;
-            }
-        }
-
         // agent based tasks automatically download artifacts from the build. 
         // when the build only produces a vsts drop that artifact is a single json
         // it resides in <builddefname>/<guid>/VSTSDrop.json
         private static string ExtractDropUrl(string workingDirectory)
         {
-            string buildDirectory = GetBuildFolder(workingDirectory);
             string guidDirectory = string.Empty;
 
             try
             {
-                // guidDirectory = Directory.GetDirectories(buildDirectory).Single();
-                guidDirectory = Directory.GetDirectories(buildDirectory).Where(directory => directory.Remove(0,directory.LastIndexOf('/') + 1) != "drop").Single();
+                guidDirectory = Directory.GetDirectories(workingDirectory).Single();
             }
             catch (Exception)
             {
-                Console.WriteLine($"The build directory, {buildDirectory}, is invalid");
+                Console.WriteLine($"The build directory, {workingDirectory}, is invalid");
                 throw;
             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Diagnostics;
+using System.Reflection;
 using Newtonsoft.Json;
 using CommandLine;
 
@@ -40,30 +41,21 @@ namespace DropDownloadCore
         private static string ExtractDropUrl(string workingDirectory)
         {
             //could take an envdir on what the build dir is for now though we just have one build
-            string buildDirectory = string.Empty;
             string guidDirectory = string.Empty;
 
-            try
-            {
-                buildDirectory = Directory.GetDirectories(workingDirectory).Single();
-            }
-            catch (Exception)
-            {
-                Console.WriteLine($"The working directory, {workingDirectory}, is invalid");
-                throw;
-            }
+            Console.WriteLine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location));
 
             try
             {
-                guidDirectory = Directory.GetDirectories(buildDirectory).Single();
+                guidDirectory = Directory.GetDirectories(workingDirectory).Single();
             }
             catch (Exception)
             {
-                Console.WriteLine($"The build directory, {buildDirectory}, is invalid");
+                Console.WriteLine($"The build directory, {workingDirectory}, is invalid");
                 throw;
             }
 
-            var dropJSONFilename = Path.Combine(workingDirectory, buildDirectory,  guidDirectory, "VSTSDrop.json");
+            var dropJSONFilename = Path.Combine(workingDirectory,  guidDirectory, "VSTSDrop.json");
 
             // https://www.newtonsoft.com/json/help/html/DeserializeAnonymousType.htm
             var definition = new { VstsDropBuildArtifact = new {VstsDropUrl ="" } };


### PR DESCRIPTION
New release downloads build artifacts manually.  Assuming that we start in the correct artifact folder instead of finding build folder.  This prevents issues when there is more than one build.  (Also, old version does not work when called from a VSTS build :) ).  Should we make this configurable?

(This would need to go in at the same time as my other PR)