### PR TITLE
Add trailing slash to docker dir to avoid exception in hash

### DIFF
--- a/VSTSDropProxy.cs
+++ b/VSTSDropProxy.cs
@@ -144,7 +144,8 @@ namespace DropDownloadCore
                 var filename = Path.GetFileName(localpath);
                 if (filename.StartsWith("dockerfile", StringComparison.OrdinalIgnoreCase))
                 {
-                    dockerdirs.Add(Path.GetDirectoryName(file.Path));
+                    var dockerdir = Path.GetDirectoryName(file.Path).Replace("\\", "/") + "/";
+                    dockerdirs.Add(dockerdir);
                 }
             }
 


### PR DESCRIPTION
The relative path specified is updated to include a trailing slash, but the docker directories saved do not. If the drop being downloaded has a dockerfile directly under the relative path an argument exception is thrown on the substring call. Avoiding this by appending a trailing slash when storing directories to be hashed. This also avoids a subtle bug that files under a different directory and happen to match the substring are incorrectly included in the hash; with a trailing slash this is avoided.